### PR TITLE
Removes artifacts into preview screens

### DIFF
--- a/src/lib/remix/util/util.js
+++ b/src/lib/remix/util/util.js
@@ -192,3 +192,69 @@ export function getScreenHTMLPreview({ screen, defaultTitle }) {
                 ${mainText}
             </div>`
 }
+
+/**
+ *
+ * @param {HTMLElement} element
+ * @returns {string}
+ */
+export function elementToHtml(element) {
+    const tmp = document.createElement('div')
+    tmp.appendChild(element)
+    return tmp.innerHTML
+}
+
+/**
+ * Удаляет ненужные для превью элементы редактора (артефакты)
+ * @param {HTMLElement} element
+ * @returns {HTMLElement}
+ */
+export function cutTextEditor(element) {
+    const rmxTextEditorList = element.querySelectorAll('.rmx-text-editor')
+
+    for (let i = 0; i < rmxTextEditorList.length; i++) {
+        const qlEditor = rmxTextEditorList[i].querySelector('.ql-editor').cloneNode(true)
+        rmxTextEditorList[i].innerHTML = `
+            <div class="ql-container ql-snow ql-disabled">
+                ${elementToHtml(qlEditor)}
+            </div>
+        `
+    }
+    return element
+}
+
+/**
+ * Удаляет рамки которые появляются при наведении/нажатии на элемент
+ * @param {HTMLElement} element
+ * @returns {HTMLElement}
+ */
+export function cutRmxEditingBorders(element) {
+    const rmxLayoutItemSelectionCntList = element.querySelectorAll('.rmx-layout_item_selection_cnt')
+
+    for (let i = 0; i < rmxLayoutItemSelectionCntList.length; i++) {
+        const item = rmxLayoutItemSelectionCntList[i]
+        item.parentNode.removeChild(item)
+    }
+
+    return element
+}
+
+/**
+ * Удаляет TextEditor и ненужные для превью Remix элементы
+ * @param {HTMLElement} element
+ * @returns {HTMLElement}
+ */
+export function removeUnnecessaryItemsFromScreen(element) {
+    const SELECTORS = ['.rmx-text-editor', '.rmx-layout_item_selection_cnt']
+    const isNeedCopy = SELECTORS.some(s => !!element.querySelector(s))
+
+    if (!isNeedCopy) {
+        return element
+    }
+
+    let copyOfElement = element.cloneNode(true)
+    copyOfElement = cutTextEditor(copyOfElement)
+    copyOfElement = cutRmxEditingBorders(copyOfElement)
+
+    return copyOfElement
+}

--- a/src/lib/remix/util/util.test.js
+++ b/src/lib/remix/util/util.test.js
@@ -1,0 +1,167 @@
+import { elementToHtml, cutTextEditor, cutRmxEditingBorders, removeUnnecessaryItemsFromScreen } from './util'
+
+describe('elementToHtml', () => {
+    it('should transform html element to string', () => {
+        const div = document.createElement('div')
+        expect(elementToHtml(div)).toEqual('<div></div>')
+
+        const innerSting = `<div><p>some text</p></div>`
+        div.innerHTML = innerSting
+        expect(elementToHtml(div)).toEqual(`<div>${innerSting}</div>`)
+    })
+})
+
+describe('cutTextEditor', () => {
+    /**
+     * Дожен заменить все что находится в .rmx-text-editor на
+     * <div class="ql-container ql-snow ql-disabled">
+     *     <div class="ql-editor">...</div>
+     * </div>
+     */
+    it('should remove unnecessary editor elements for preview', () => {
+        const template = `
+            <div class="rmx-text-editor">
+                <ul>...</ul>
+                <ul>...</ul>
+                <ul>...</ul>
+                some text
+                <div class="ql-editor">
+                    <p>Text 1</p>
+                    <p>Text 2</p>
+                </div>
+                <div>unnecessary elements</div>
+                <ul>...</ul>
+            </div>
+            <div class="rmx-text-editor">
+                <ul>...</ul>
+                <div class="ql-editor">
+                    <p>Text 2</p>
+                </div>
+                <ul>...</ul>
+            </div>
+        `
+        const resultTemplate = `
+            <div class="rmx-text-editor">
+                <div class="ql-container ql-snow ql-disabled">
+                    <div class="ql-editor">
+                        <p>Text 1</p>
+                        <p>Text 2</p>
+                    </div>
+                </div>
+            </div>
+            <div class="rmx-text-editor">
+                <div class="ql-container ql-snow ql-disabled">
+                    <div class="ql-editor">
+                        <p>Text 2</p>
+                    </div>
+                </div>
+            </div>
+        `.replace(/ |\n/g, '')
+
+        document.body.innerHTML = template
+        const templateAsString = cutTextEditor(document.body).innerHTML.replace(/ |\n/g, '')
+
+        expect(templateAsString).toEqual(resultTemplate)
+    })
+})
+
+describe('cutRmxEditingBorders', () => {
+    /**
+     * Дожен удалить все элементы с классом .rmx-layout_item_selection_cnt
+     */
+    it('should remove unnecessary remix borders elements for preview', () => {
+        const template = `
+            <div>
+                <div>Content</div>
+                <div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                </div>
+            </div>
+        `
+        const resultTemplate = `
+            <div>
+                <div>Content</div>
+                <div></div>
+            </div>`.replace(/ |\n/g, '')
+
+        document.body.innerHTML = template
+        const templateAsString = cutRmxEditingBorders(document.body).innerHTML.replace(/ |\n/g, '')
+
+        expect(templateAsString).toEqual(resultTemplate)
+    })
+})
+
+describe('removeUnnecessaryItemsFromScreen', () => {
+    /**
+     * Дожен заменить все что находится в .rmx-text-editor на
+     * <div class="ql-container ql-snow ql-disabled">
+     *     <div class="ql-editor">...</div>
+     * </div>
+     * и удалить элементы с классом .rmx-layout_item_selection_cnt (бордеры при выделении элемента)
+     */
+    it('should remove unnecessary elements (editor and remix borders)', () => {
+        const template = `
+            <div class="rmx-text-editor">
+                <ul>...</ul>
+                <ul>...</ul>
+                <ul>...</ul>
+                some text
+                <div class="ql-editor">
+                    <p>Text 1</p>
+                    <p>Text 2</p>
+                    <div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                </div>
+                </div>
+                <div>unnecessary elements</div>
+                <ul>...</ul>
+            </div>
+            <div class="rmx-text-editor">
+                <ul>...</ul>
+                <div class="ql-editor">
+                    <p>Text 2</p>
+                    <div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                    <div class="rmx-layout_item_selection_cnt"></div>
+                </div>
+                </div>
+                <ul>...</ul>
+            </div>
+        `
+        const resultTemplate = `
+            <div class="rmx-text-editor">
+                <div class="ql-container ql-snow ql-disabled">
+                    <div class="ql-editor">
+                        <p>Text 1</p>
+                        <p>Text 2</p>
+                        <div></div>
+                    </div>
+                </div>
+            </div>
+            <div class="rmx-text-editor">
+                <div class="ql-container ql-snow ql-disabled">
+                    <div class="ql-editor">
+                        <p>Text 2</p>
+                        <div></div>
+                    </div>
+                </div>
+            </div>
+        `.replace(/ |\n/g, '')
+
+        document.body.innerHTML = template
+        const templateAsString = removeUnnecessaryItemsFromScreen(document.body).innerHTML.replace(/ |\n/g, '')
+
+        expect(templateAsString).toEqual(resultTemplate)
+    })
+})


### PR DESCRIPTION
Решил перед отправкой экранов на превью удалять элементы от quill редактора и remix бордеры (которые появляются при перетаскивании/наведении/нажатии).
До:
<img width="627" alt="Screenshot 2020-05-28 at 19 48 37" src="https://user-images.githubusercontent.com/24718000/83144488-9d18e780-a11d-11ea-848b-ea4dd9e5fd7e.png">
<img width="610" alt="Screenshot 2020-05-28 at 19 50 05" src="https://user-images.githubusercontent.com/24718000/83144492-9db17e00-a11d-11ea-840c-b61f13295f45.png">
После:
<img width="612" alt="Screenshot 2020-05-28 at 19 48 04" src="https://user-images.githubusercontent.com/24718000/83144477-99856080-a11d-11ea-9298-bf4980940bdb.png">
<img width="619" alt="Screenshot 2020-05-28 at 19 50 39" src="https://user-images.githubusercontent.com/24718000/83144496-9e4a1480-a11d-11ea-8540-8d362480966a.png">
Сократился размер передаваемого шаблона:
<img width="426" alt="Screenshot 2020-05-28 at 19 21 43" src="https://user-images.githubusercontent.com/24718000/83144658-df422900-a11d-11ea-99f2-07a9d39ace1a.png">
